### PR TITLE
Add support for HuskTowns claims plugin 

### DIFF
--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT'
     implementation 'io.papermc:paperlib:1.0.6'
+    implementation 'biz.donvi:ArgsChecker:1'
     implementation 'biz.donvi:EvenDistribution:1.1.1'
     implementation 'biz.donvi:GnuPlotter:1.1'
 //    implementation project(":patch-1-12-2")
@@ -25,7 +26,7 @@ dependencies {
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     compileOnly 'com.github.TechFortress:GriefPrevention:16.17.1'
     compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.5'
-    compileOnly 'me.William278:HuskTowns:1.5.3'
+    compileOnly 'com.github.WiIIiam278:HuskTowns:a8e28c5fe8'
 }
 
 processResources {
@@ -47,7 +48,7 @@ artifacts {
 
 task copyToMainOut(type: Copy) {
     dependsOn(tasks.build)
-//    delete file("../build-output-final/").listFiles()
+    delete file("../build-output-final/").listFiles()
     from file("build/libs/Core-${project.version}-all.jar")
     into file("../build-output-final")
     rename 'Core-', 'JakesRTP-v'

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     compileOnly 'com.github.TechFortress:GriefPrevention:16.17.1'
     compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.5'
-    compileOnly 'com.github.WiIIiam278:HuskTowns:a8e28c5fe8'
+    compileOnly 'com.github.WiIIiam278:HuskTowns:1.5.3'
 }
 
 processResources {

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -8,22 +8,24 @@ repositories {
     maven { url 'https://papermc.io/repo/repository/maven-public/' }
     maven { url 'https://repo.codemc.io/repository/maven-public/' }
     maven { url 'https://jitpack.io' }
-    maven { url "https://maven.enginehub.org/repo/" }
+    maven { url 'https://maven.enginehub.org/repo/' }
+    maven { url 'https://repo.mikeprimm.com/'}
 }
 
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT'
     implementation 'io.papermc:paperlib:1.0.6'
-    implementation 'biz.donvi:ArgsChecker:1'
     implementation 'biz.donvi:EvenDistribution:1.1.1'
     implementation 'biz.donvi:GnuPlotter:1.1'
 //    implementation project(":patch-1-12-2")
+    compileOnly 'us.dynmap:dynmap-api:3.1'
     compileOnly 'org.popcraft:chunky-common:1.2.86'
     compileOnly 'org.popcraft:chunkyborder:1.0.38'
     compileOnly 'com.github.Brettflan:WorldBorder:c0d1772418'
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     compileOnly 'com.github.TechFortress:GriefPrevention:16.17.1'
     compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.5'
+    compileOnly 'me.William278:HuskTowns:1.5.3'
 }
 
 processResources {
@@ -45,7 +47,7 @@ artifacts {
 
 task copyToMainOut(type: Copy) {
     dependsOn(tasks.build)
-    delete file("../build-output-final/").listFiles()
+//    delete file("../build-output-final/").listFiles()
     from file("build/libs/Core-${project.version}-all.jar")
     into file("../build-output-final")
     rename 'Core-', 'JakesRTP-v'

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/ClaimsManager.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/ClaimsManager.java
@@ -2,13 +2,11 @@ package biz.donvi.jakesRTP.claimsIntegrations;
 
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
-import me.william278.husktowns.HuskTowns;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -69,11 +67,11 @@ public class ClaimsManager {
             } else return false;
         });
 
-        // HuskTowns support!
+        //HuskTowns support!
         generalPluginLoader("husk-towns", "HuskTowns", (pluginName) -> {
             Plugin plugin;
             if ((plugin = tryGetPlugin(pluginName)) != null) {
-                restrictors.add(new LrHuskTowns((HuskTowns) plugin));
+                restrictors.add(new LrHuskTowns(plugin));
                 return true;
             } else return false;
         });

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/ClaimsManager.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/ClaimsManager.java
@@ -2,6 +2,7 @@ package biz.donvi.jakesRTP.claimsIntegrations;
 
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.william278.husktowns.HuskTowns;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
@@ -64,6 +65,15 @@ public class ClaimsManager {
             Plugin plugin;
             if ((plugin = tryGetPlugin(pluginName)) != null) {
                 restrictors.add(new LrWorldGuard((WorldGuardPlugin) plugin));
+                return true;
+            } else return false;
+        });
+
+        // HuskTowns support!
+        generalPluginLoader("husk-towns", "HuskTowns", (pluginName) -> {
+            Plugin plugin;
+            if ((plugin = tryGetPlugin(pluginName)) != null) {
+                restrictors.add(new LrHuskTowns((HuskTowns) plugin));
                 return true;
             } else return false;
         });

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LocationRestrictor.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LocationRestrictor.java
@@ -1,9 +1,7 @@
 package biz.donvi.jakesRTP.claimsIntegrations;
 
-import biz.donvi.jakesRTP.JakesRtpPlugin;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public interface LocationRestrictor {
 

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrGriefPrevention.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrGriefPrevention.java
@@ -1,12 +1,9 @@
 package biz.donvi.jakesRTP.claimsIntegrations;
 
-import biz.donvi.jakesRTP.JakesRtpPlugin;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
-
-import static org.bukkit.Bukkit.getServer;
 
 public class LrGriefPrevention implements LocationRestrictor {
     protected GriefPrevention cmPlugin;

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrHuskTowns.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrHuskTowns.java
@@ -1,0 +1,25 @@
+package biz.donvi.jakesRTP.claimsIntegrations;
+
+import me.william278.husktowns.HuskTowns;
+import me.william278.husktowns.HuskTownsAPI;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+public class LrHuskTowns implements LocationRestrictor {
+
+    protected HuskTowns cmPlugin;
+
+    public LrHuskTowns(HuskTowns cmPlugin) {
+        this.cmPlugin = cmPlugin;
+    }
+
+    @Override
+    public Plugin supporterPlugin() {
+        return cmPlugin;
+    }
+
+    @Override
+    public boolean denyLandingAtLocation(Location location) {
+        return (!HuskTownsAPI.getInstance().isWilderness(location));
+    }
+}

--- a/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrHuskTowns.java
+++ b/Core/src/main/java/biz/donvi/jakesRTP/claimsIntegrations/LrHuskTowns.java
@@ -1,15 +1,14 @@
 package biz.donvi.jakesRTP.claimsIntegrations;
 
-import me.william278.husktowns.HuskTowns;
 import me.william278.husktowns.HuskTownsAPI;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
 
 public class LrHuskTowns implements LocationRestrictor {
 
-    protected HuskTowns cmPlugin;
+    protected Plugin cmPlugin;
 
-    public LrHuskTowns(HuskTowns cmPlugin) {
+    public LrHuskTowns(Plugin cmPlugin) {
         this.cmPlugin = cmPlugin;
     }
 

--- a/Core/src/main/resources/config.yml
+++ b/Core/src/main/resources/config.yml
@@ -60,6 +60,7 @@ land-claim-support:
   force-disable-all: false
   grief-prevention: true
   world-guard: true
+  husk-towns: true
 
 #### logging
 # Which messages do you want to log? You can ignore log messages for settings that are disabled.

--- a/Core/src/main/resources/plugin.yml
+++ b/Core/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ softdepend:
   # For claims support
   - 'GriefPrevention'
   - 'WorldGuard'
+  - 'HuskTowns'
 
 commands:
   jrtpdebug:


### PR DESCRIPTION
This PR adds support for a new claim plugin, [HuskTowns](https://github.com/WiIIiam278/HuskTownsAPI/) (API via jitpack dependency).
* Added a new config.yml option; `husk-towns: true/false`
* Added location restrictor class for HuskTowns that denies the random position if it lands within a HuskTowns claim. Note that the `cmPlugin` object for HuskTowns is the abstract BukkitPlugin type as I don't provide access to the HuskTowns main class via the HuskTownsAPI (though this doesn't make a difference)
* Fixed inconsistent quotation usage on a repo in build.gradle
* Removed a few unused imports